### PR TITLE
Changed zf2 version and keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,15 @@
 {
-    
     "name": "tawfekov/zf2entityaudit",
     "description": "EntityAudit Module for Zend Framework2 + Doctrine2, online demo http://bit.ly/ZF2EntityAudit",
     "type": "zf-module",
     "license": "MIT",
     "keywords": [
-        "entityAudit",
-	"zf2",
-	"zend framework2",
-        "php",
-	"database",
-	"persistence",
-	"Audit"
+        "audit",
+        "entity",
+        "Doctrine 2"
+	    "zf2",
+	    "database",
+	    "persistence",
     ],
     "homepage": "http://bit.ly/ZF2EntityAudit",
     "authors": [
@@ -23,9 +21,9 @@
     ],
     "require": {
         "php": ">=5.3.0",
-	"zendframework/zendframework" : "dev-master",
-	"doctrine/doctrine-orm-module": "dev-master",
-	"simplethings/entity-audit-bundle": "dev-master"
+	    "zendframework/zendframework" : ">=2.0.5",
+	    "doctrine/doctrine-orm-module": "dev-master",
+	    "simplethings/entity-audit-bundle": "dev-master"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Updated the composer to not require latest dev-master for zf2.  If this is to be used in production env's you can't count on the latest and greatest being the composer.lock'ed version.

Cleaned up keywords a little.

This looks like a great app.  I wrote one which did the same thing some time ago but you've done a better and more complete job with this.  I'll be using it as a cornerstone to my db.etree.org rewrite.
