### PR TITLE
collision with Project Version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "doctrine/doctrine-module": "0.8.*@dev",
         "doctrine/doctrine-orm-module": "0.8.*@dev",
         "zf-commons/zfc-user": ">=0.1.1",
-        "zf-commons/zfc-user-doctrine-orm": "dev-master"
+        "zf-commons/zfc-user-doctrine-orm": "0.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
this resolve the collision with the Project Version if 0.\* is set as required Version
pls dont use \* or dev-master for stable

tia
CodeBabo
