### PR TITLE
Views

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -127,7 +127,7 @@ class Module implements ConsoleUsageProviderInterface
     {
          return array(
              "update" => "update the database from 0.1 to be  0.2 compatibale ",
-             "initialize" => "create initial revisions for all audited entities that do not have any revision"
+             "initialize-revisions <userEmail>" => "create initial revisions for all audited entities that do not have any revision"
           );
     }
 }

--- a/Module.php
+++ b/Module.php
@@ -47,6 +47,15 @@ class Module implements ConsoleUsageProviderInterface
                     $auditconfig = new Configuration();
                     $auditconfig->setAuditedEntityClasses($config['zf2-entity-audit']['entities']);
                     $auditconfig->setZfcUserEntityClass($config['zf2-entity-audit']['zfcuser.entity_class']);
+
+                    if (!empty($config['zf2-entity-audit']['note'])) {
+                        $auditconfig->setNote($config['zf2-entity-audit']['note']);
+                    }
+
+                    if (!empty($config['zf2-entity-audit']['noteFormField'])) {
+                        $auditconfig->setNoteFormField($config['zf2-entity-audit']['noteFormField']);
+                    }
+
                     return $auditconfig;
                 },
 

--- a/Module.php
+++ b/Module.php
@@ -8,6 +8,7 @@ use ZF2EntityAudit\Audit\Manager ;
 use ZF2EntityAudit\EventListener\CreateSchemaListener;
 use ZF2EntityAudit\EventListener\LogRevisionsListener;
 use ZF2EntityAudit\View\Helper\DateTimeFormatter;
+use ZF2EntityAudit\View\Helper\EntityLabel;
 use ZF2EntityAudit\View\Helper\User as UserBlock;
 use ZF2EntityAudit\View\Helper\Dump ;
 use Zend\ModuleManager\Feature\ConsoleUsageProviderInterface;
@@ -110,6 +111,10 @@ class Module implements ConsoleUsageProviderInterface
                     $helper->setZfcUserEntityClass($config['zf2-entity-audit']['zfcuser.entity_class']);
                     return $helper ;
                 },
+                'EntityLabel' => function($sm){
+                    $helper         = new EntityLabel();
+                    return $helper ;
+                },
                 'Dump' => function(){
                      $helper = new Dump();
                      return $helper;
@@ -121,7 +126,8 @@ class Module implements ConsoleUsageProviderInterface
     public function getConsoleUsage(Console $console)
     {
          return array(
-             "update" => "update the database from 0.1 to be  0.2 compatibale "
+             "update" => "update the database from 0.1 to be  0.2 compatibale ",
+             "initialize" => "create initial revisions for all audited entities that do not have any revision"
           );
     }
 }

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -110,6 +110,15 @@ return array(
                             'action' => 'update'
                         )
                     )
+                ),
+                'ititial-revisions' => array(
+                    'options' => array(
+                        'route' => 'initialize',
+                        'defaults' => array(
+                            'controller' => 'ZF2EntityAudit\Controller\Console',
+                            'action' => 'createInitialRevisions'
+                        )
+                    )
                 )
             )
         )

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -111,12 +111,13 @@ return array(
                         )
                     )
                 ),
-                'ititial-revisions' => array(
+                'ititialize-revisions' => array(
                     'options' => array(
-                        'route' => 'initialize',
+                        'route' => 'initialize-revisions <userEmail>',
                         'defaults' => array(
                             'controller' => 'ZF2EntityAudit\Controller\Console',
-                            'action' => 'createInitialRevisions'
+                            'action' => 'createInitialRevisions',
+                            'userEmail' => null
                         )
                     )
                 )

--- a/config/zf2entityaudit.global.php.dist
+++ b/config/zf2entityaudit.global.php.dist
@@ -5,7 +5,8 @@ return array(
         ),
         'ui' => array(
             'datetime.format' => 'r',
-            'page.limit'    => '20'
+            'page.limit'    => '20',
+            'ignore.prefix' => 'Application\Entity\\'
         ),
         'zfcuser.integration' => true,
         'zfcuser.entity_class' => 'ZfcUser\Entity\User'

--- a/config/zf2entityaudit.global.php.dist
+++ b/config/zf2entityaudit.global.php.dist
@@ -6,7 +6,7 @@ return array(
         'ui' => array(
             'datetime.format' => 'r',
             'page.limit'    => '20',
-            'ignore.prefix' => 'Application\Entity\\'
+            'ignore.prefix' => 'Application\Entity\\' // The text here will be removed from the entity class wherever it is displayed in the views.
         ),
         'zfcuser.integration' => true,
         'zfcuser.entity_class' => 'ZfcUser\Entity\User',

--- a/config/zf2entityaudit.global.php.dist
+++ b/config/zf2entityaudit.global.php.dist
@@ -6,7 +6,8 @@ return array(
         'ui' => array(
             'datetime.format' => 'r',
             'page.limit'    => '20',
-            'ignore.prefix' => 'Application\Entity\\' // The text here will be removed from the entity class wherever it is displayed in the views.
+            'ignore.prefix' => 'Application\Entity\\', // The text here will be removed from the entity class wherever it is displayed in the views.
+            'max.entities.per.revision' => 50 // Because initial revisions can have loads of entities, just cut off display after this many
         ),
         'zfcuser.integration' => true,
         'zfcuser.entity_class' => 'ZfcUser\Entity\User',

--- a/config/zf2entityaudit.global.php.dist
+++ b/config/zf2entityaudit.global.php.dist
@@ -9,7 +9,8 @@ return array(
             'ignore.prefix' => 'Application\Entity\\'
         ),
         'zfcuser.integration' => true,
-        'zfcuser.entity_class' => 'ZfcUser\Entity\User'
+        'zfcuser.entity_class' => 'ZfcUser\Entity\User',
+        'noteFormField' => 'auditNote' // Add a form field with this name to any form where an audited entity is edited. If the field has a value and the entity changes, the note will be saved with the revision.
     ),
 );
 

--- a/src/ZF2EntityAudit/Audit/Configuration.php
+++ b/src/ZF2EntityAudit/Audit/Configuration.php
@@ -71,6 +71,11 @@ class Configuration
         $this->revisionTableName = $revisionTableName;
     }
 
+    public function getAuditedEntityClasses()
+    {
+        return $this->auditedEntityClasses;
+    }
+
     public function setAuditedEntityClasses(array $classes)
     {
         $this->auditedEntityClasses = $classes;

--- a/src/ZF2EntityAudit/Audit/Configuration.php
+++ b/src/ZF2EntityAudit/Audit/Configuration.php
@@ -19,6 +19,7 @@ class Configuration
     private $note = "";
     private $ipaddress = "127.0.0.1";
     private $entityClass = "ZfcUser\Entity\User";
+    private $noteFormField = 'auditNote';
 
     public function getTablePrefix()
     {
@@ -113,7 +114,24 @@ class Configuration
 
     public function getNote()
     {
+        if (empty($this->note)) {
+            if (!empty($_REQUEST[$this->getNoteFormField()])) {
+                $this->note = $_REQUEST[$this->getNoteFormField()];
+            }
+        }
+
         return $this->note;
+    }
+
+    public function getNoteFormField(): string
+    {
+        return $this->noteFormField;
+    }
+
+    public function setNoteFormField(string $noteFormField): Configuration
+    {
+        $this->noteFormField = $noteFormField;
+        return $this;
     }
 
     public function getIpAddress()

--- a/src/ZF2EntityAudit/Controller/ConsoleController.php
+++ b/src/ZF2EntityAudit/Controller/ConsoleController.php
@@ -2,10 +2,12 @@
 
 namespace ZF2EntityAudit\Controller;
 
+use Doctrine\ORM\EntityManager;
 use Zend\Mvc\Controller\AbstractActionController;
 use Zend\View\Model\ViewModel;
 use Zend\Console\Request as ConsoleRequest;
 use RuntimeException;
+use ZF2EntityAudit\EventListener\LogRevisionsListener;
 
 class ConsoleController extends AbstractActionController
 {
@@ -27,10 +29,10 @@ class ConsoleController extends AbstractActionController
             throw new RuntimeException('You can only use this action from a console!');
         }
         $sl = $this->getServiceLocator();
-        $em = $sl->get("doctrine.entitymanager.orm_default");
+        $em = $this->getEntityManager();
         $conn = $em->getConnection();
-        $auditConfig = $sl->get("auditConfig");
-        $revisionTableName = $auditConfig->getRevisionTableName();
+        //$auditConfig = $sl->get("auditConfig");
+        $revisionTableName = $this->getAuditConfig()->getRevisionTableName();
         $revsions = $conn->createQueryBuilder()->select("r.*")->from($revisionTableName, "r")->execute()->fetchAll();
         echo "- start updating ";
         foreach ($revsions as $r) {
@@ -58,5 +60,86 @@ class ConsoleController extends AbstractActionController
         echo "- './vendor/bin/doctrine-module orm:schema-tool:update --force' to execute  some sql  \n";
         echo "- then you should be able to work as before ";
         echo "- Done";
+    }
+
+    public function createInitialRevisionsAction()
+    {
+        $log = $this->getLogRvisionListener();
+        $uow = $this->getEntityManager()->getUnitOfWork();
+
+        //echo 'Yep!'; die;
+        $createdCount = 0;
+        foreach ($this->getAuditConfig()->getAuditedEntityClasses() as $className) {
+            echo $className . "\n";
+            $class = $this->getEntityManager()->getClassMetadata($className);
+            
+            foreach ($this->getEntityManager()->getRepository($className)->findAll() as $entity) {
+                echo $entity->getId() . "\n";
+                $entityId = $entity->getId();
+
+                echo $entityId . "\n";
+                $revisions = $this->getAuditReader()->findRevisions($className, $entityId);
+
+
+                if (!count($revisions)) {
+                    echo 'needs revision' . "\n";
+
+
+                    //$data = $uow->getOriginalEntityData($entity);
+                    $entityData = $log->getOriginalEntityData($entity);
+                    //var_dump($data); die();
+
+                    //$entityData = $entity->toArray();
+
+                    $log->saveRevisionEntityData($class, $entityData, 'INS');
+
+                    die("one only\n");
+                } else {
+                    //$count = count($revisions);
+                    //echo "has $count revisions\n";
+                }
+
+            }
+        }
+    }
+
+    /**
+     * @return \ZF2EntityAudit\Audit\Configuration
+     */
+    protected function getAuditConfig()
+    {
+        /** @var \ZF2EntityAudit\Audit\Configuration $auditConfig */
+        $auditConfig = $this->getServiceLocator()->get('auditConfig');
+
+        return $auditConfig;
+    }
+
+    /**
+     * @return EntityManager
+     */
+    protected function getEntityManager()
+    {
+        $sl = $this->getServiceLocator();
+        return $sl->get("doctrine.entitymanager.orm_default");
+    }
+
+    /**
+     * @return \ZF2EntityAudit\Audit\Reader
+     */
+    protected function getAuditReader()
+    {
+        return $this->getServiceLocator()->get('auditReader');
+    }
+
+    /**
+     * @return LogRevisionsListener
+     */
+    protected function getLogRvisionListener()
+    {
+        $auditManager = $this->getServiceLocator()->get('AuditManager');
+        $manager = new LogRevisionsListener($auditManager);
+        $manager->setEntityManager($this->getEntityManager());
+
+        return $manager;
     }
 }

--- a/src/ZF2EntityAudit/Controller/IndexController.php
+++ b/src/ZF2EntityAudit/Controller/IndexController.php
@@ -42,6 +42,7 @@ class IndexController extends AbstractActionController
         return new ViewModel(array(
             'paginator'   => $paginator ,
             'auditReader' => $auditReader,
+            'prefixToIgnore' => $this->getPrefixToIgnore()
         ));
     }
 
@@ -62,6 +63,7 @@ class IndexController extends AbstractActionController
         return new ViewModel(array(
             'revision' => $revision,
             'changedEntities' => $changedEntities,
+            'prefixToIgnore' => $this->getPrefixToIgnore()
         ));
     }
 
@@ -79,11 +81,27 @@ class IndexController extends AbstractActionController
         $ids       = explode(',', $id);
         $revisions = $this->getServiceLocator()->get('auditReader')->findRevisions($className, $ids);
 
+
         return new ViewModel(array(
                     'id' => $id,
                     'className' => $className,
                     'revisions' => $revisions,
+                    'prefixToIgnore' => $this->getPrefixToIgnore()
                 ));
+    }
+
+    protected function getPrefixToIgnore()
+    {
+        $sm             = $this->getServiceLocator() ;
+        $config         = $sm->get("Config");
+        $ZF2AuditConfig = $config["zf2-entity-audit"];
+        $prefixToIgnore = null;
+
+        if (!empty($ZF2AuditConfig['ui']['ignore.prefix'])) {
+            $prefixToIgnore = $ZF2AuditConfig['ui']['ignore.prefix'];
+        }
+
+        return $prefixToIgnore;
     }
 
     /**
@@ -108,6 +126,7 @@ class IndexController extends AbstractActionController
             'className' => $className,
             'entity' => $entity,
             'data' => $data,
+            'prefixToIgnore' => $this->getPrefixToIgnore()
         ));
     }
 
@@ -147,6 +166,7 @@ class IndexController extends AbstractActionController
             'oldRev' => $oldRev,
             'newRev' => $newRev,
             'diff' => $diff,
+            'prefixToIgnore' => $this->getPrefixToIgnore()
         ));
     }
 

--- a/src/ZF2EntityAudit/Controller/IndexController.php
+++ b/src/ZF2EntityAudit/Controller/IndexController.php
@@ -42,7 +42,8 @@ class IndexController extends AbstractActionController
         return new ViewModel(array(
             'paginator'   => $paginator ,
             'auditReader' => $auditReader,
-            'prefixToIgnore' => $this->getPrefixToIgnore()
+            'prefixToIgnore' => $this->getPrefixToIgnore(),
+            'auditConfig' => $ZF2AuditConfig
         ));
     }
 

--- a/src/ZF2EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/ZF2EntityAudit/EventListener/LogRevisionsListener.php
@@ -224,6 +224,7 @@ class LogRevisionsListener implements EventSubscriber
                 }
             }
         }
+
         $this->conn->executeUpdate($this->getInsertRevisionSQL($class), $params, $types);
     }
 

--- a/src/ZF2EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/ZF2EntityAudit/EventListener/LogRevisionsListener.php
@@ -108,13 +108,14 @@ class LogRevisionsListener implements EventSubscriber
         }
     }
 
+
     /**
      * get original entity data, including versioned field, if "version" constraint is used
      *
      * @param  mixed $entity
      * @return array
      */
-    private function getOriginalEntityData($entity)
+    public function getOriginalEntityData($entity)
     {
         $class = $this->em->getClassMetadata(get_class($entity));
         $data = $this->uow->getOriginalEntityData($entity);
@@ -192,7 +193,7 @@ class LogRevisionsListener implements EventSubscriber
      * @param array         $entityData
      * @param string        $revType
      */
-    private function saveRevisionEntityData($class, $entityData, $revType)
+    public function saveRevisionEntityData($class, $entityData, $revType)
     {
         $params = array($this->getRevisionId(), $revType);
         $types = array(\PDO::PARAM_INT, \PDO::PARAM_STR);
@@ -224,5 +225,15 @@ class LogRevisionsListener implements EventSubscriber
             }
         }
         $this->conn->executeUpdate($this->getInsertRevisionSQL($class), $params, $types);
+    }
+
+    public function setEntityManager($entityManager)
+    {
+        $this->em = $entityManager;
+        $this->uow = $entityManager->getUnitOfWork();
+        $this->conn = $this->em->getConnection();
+        $this->platform = $this->conn->getDatabasePlatform();
+
+        return $this;
     }
 }

--- a/src/ZF2EntityAudit/View/Helper/EntityLabel.php
+++ b/src/ZF2EntityAudit/View/Helper/EntityLabel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ZF2EntityAudit\View\Helper;
+
+use Zend\View\Helper\AbstractHelper;
+use Doctrine\ORM\EntityManager;
+
+class EntityLabel extends AbstractHelper
+{
+    public function __invoke($entity, $className, $id, $prefixToIgnore = null)
+    {
+        // By default, show the class name and ID
+        $className = str_replace($prefixToIgnore, '', $className);
+        $label = "$className identifier $id";
+
+        // But if the entity has __toString(), show that instead
+        if ($entity && method_exists($entity, '__toString')) {
+            $label = $entity->__toString();
+        }
+
+        return $label;
+    }
+}

--- a/src/ZF2EntityAudit/View/Helper/User.php
+++ b/src/ZF2EntityAudit/View/Helper/User.php
@@ -34,7 +34,7 @@ class User extends AbstractHelper
         if ($user->getEmail()) {
             $html .= "<strong>Email Address</strong>: {$this->getView()->escapeHtml($user->getEmail())}</p>";
         }
-        $html .= '<span class="label label-info">15 insert</span> ';
+        //$html .= '<span class="label label-info">15 insert</span> ';
         $html .= '<span class="label label-warning">8 updates</span> ';
         $html .= '<span class="label label-danger">15 delete</span> ';
         $html .= '</div>';

--- a/src/ZF2EntityAudit/View/Helper/User.php
+++ b/src/ZF2EntityAudit/View/Helper/User.php
@@ -29,14 +29,14 @@ class User extends AbstractHelper
             $html .= "<p><strong>DisplayName</strong>: {$this->getView()->escapeHtml($user->getDisplayName())}<br/>";
         }
         if ($user->getUserName()) {
-            $html .= "<strong>UserName</strong>: {$this->getView()->escapeHtml($user->getUserName())}<br/>";
+            //$html .= "<strong>UserName</strong>: {$this->getView()->escapeHtml($user->getUserName())}<br/>";
         }
         if ($user->getEmail()) {
             $html .= "<strong>Email Address</strong>: {$this->getView()->escapeHtml($user->getEmail())}</p>";
         }
         //$html .= '<span class="label label-info">15 insert</span> ';
-        $html .= '<span class="label label-warning">8 updates</span> ';
-        $html .= '<span class="label label-danger">15 delete</span> ';
+        //$html .= '<span class="label label-warning">8 updates</span> ';
+        //$html .= '<span class="label label-danger">15 delete</span> ';
         $html .= '</div>';
         $html .= '<div class="col-lg-4">';
         $html .= '<div>'.$this->Gravatar($user->getEmail()).'</div>';

--- a/view/zf2-entity-audit/index/compare.phtml
+++ b/view/zf2-entity-audit/index/compare.phtml
@@ -1,4 +1,4 @@
-<h1>Comparing <?php echo $this->escapeHtml($className); ?> with identifiers of
+<h1>Comparing <?php echo $this->escapeHtml(str_replace($prefixToIgnore, '', $className)); ?> with identifier of
     <?= $id ?> between revisions <?php echo $this->escapeHtml($oldRev); ?> and <?php echo $this->escapeHtml($newRev); ?> </h1>
 <div class="row">
     <div class="col-lg-12">

--- a/view/zf2-entity-audit/index/index.phtml
+++ b/view/zf2-entity-audit/index/index.phtml
@@ -89,15 +89,16 @@
                                     echo 'info';
                             }
                             ?>">
-                                    <?php echo $this->escapeHtml($displayClassName); ?>
+                                <?php echo $this->escapeHtml($displayClassName); ?>
+                                <?php
+                                $entity = $ce->getEntity()
+                                if (method_exists($entity, '__toString')) {
+                                    echo ': ' . $entity->__toString();
+                                } ?>
                             </span>
                             </a>
                             <br>
-                            <?php $entity = $ce->getEntity() ?>
-                            <?php if (method_exists($entity, '__toString')): ?>
-                                <?php echo $entity->__toString() ?>
-                                <br>
-                            <?php endif ?>
+
                             <?php
                             $i++;
                         }

--- a/view/zf2-entity-audit/index/index.phtml
+++ b/view/zf2-entity-audit/index/index.phtml
@@ -91,7 +91,7 @@
                             ?>">
                                 <?php echo $this->escapeHtml($displayClassName); ?>
                                 <?php
-                                $entity = $ce->getEntity()
+                                $entity = $ce->getEntity();
                                 if (method_exists($entity, '__toString')) {
                                     echo ': ' . $entity->__toString();
                                 } ?>

--- a/view/zf2-entity-audit/index/index.phtml
+++ b/view/zf2-entity-audit/index/index.phtml
@@ -62,6 +62,7 @@
                     <td>
                         <?php
                         $changedEntities = $this->auditReader->findEntitesChangedAtRevision($revision["id"]);
+                        $entityCount = 0;
                         foreach ($changedEntities as $ce) {
                             $displayClassName = str_replace($prefixToIgnore, '', $ce->getClassName());
                             ?>
@@ -101,6 +102,11 @@
 
                             <?php
                             $i++;
+                            $entityCount++;
+                            if (!empty($auditConfig['ui']['max.entities.per.revision']) &&
+                                $entityCount >= $auditConfig['ui']['max.entities.per.revision']) {
+                                break;
+                            }
                         }
                         ?>
                     </td>

--- a/view/zf2-entity-audit/index/index.phtml
+++ b/view/zf2-entity-audit/index/index.phtml
@@ -10,6 +10,7 @@
                 <th>Revision</th>
                 <th>Time of Action</th>
                 <th>Changed Entities</th>
+                <th>Note</th>
                 <th>User Information</th>
                 <th>Ip address</th>
                 <th>Advanced Actions</th>
@@ -101,6 +102,9 @@
                             $i++;
                         }
                         ?>
+                    </td>
+                    <td>
+                        <?php echo $revision['note'] ?>
                     </td>
                     <td>
                         <?php echo $this->UserBlock($revision["user_id"]);?>

--- a/view/zf2-entity-audit/index/index.phtml
+++ b/view/zf2-entity-audit/index/index.phtml
@@ -91,6 +91,11 @@
                             </span>
                             </a>
                             <br>
+                            <?php $entity = $ce->getEntity() ?>
+                            <?php if (method_exists($entity, '__toString')): ?>
+                                <?php echo $entity->__toString() ?>
+                                <br>
+                            <?php endif ?>
                             <?php
                             $i++;
                         }
@@ -108,7 +113,7 @@
                     </td>
 
                     <td>
-                        <div class="btn-group">
+                        <!--div class="btn-group" class="display: none">
                             <button class="btn btn-danger">Danger</button>
                             <button class="btn btn-danger dropdown-toggle" data-toggle="dropdown"><span class="caret"></span></button>
                             <ul class="dropdown-menu">
@@ -118,7 +123,7 @@
                                 <li class="divider"></li>
                                 <li><a href="#">Separated link</a></li>
                             </ul>
-                        </div>
+                        </div-->
                     </td>
                 </tr>
             <?php

--- a/view/zf2-entity-audit/index/index.phtml
+++ b/view/zf2-entity-audit/index/index.phtml
@@ -62,6 +62,7 @@
                         <?php
                         $changedEntities = $this->auditReader->findEntitesChangedAtRevision($revision["id"]);
                         foreach ($changedEntities as $ce) {
+                            $displayClassName = str_replace($prefixToIgnore, '', $ce->getClassName());
                             ?>
                             <?php $id = $ce->getId(); ?>
                             <a href="<?=
@@ -87,7 +88,7 @@
                                     echo 'info';
                             }
                             ?>">
-                                    <?php  echo $this->escapeHtml($ce->getClassName()); ?>
+                                    <?php echo $this->escapeHtml($displayClassName); ?>
                             </span>
                             </a>
                             <br>

--- a/view/zf2-entity-audit/index/viewentity.phtml
+++ b/view/zf2-entity-audit/index/viewentity.phtml
@@ -15,13 +15,14 @@ $this->url('audit_compare',
 
                 <thead>
                 <tr>
-                    <th colspan="3">&nbsp;</th>
+                    <th colspan="4">&nbsp;</th>
                     <th colspan="2">Compare</th>
                 </tr>
                 <tr>
                     <th>Revision</th>
                     <th>Timestamp</th>
                     <th>User</th>
+                    <th>Note</th>
                     <th>Old</th>
                     <th>New</th>
                 </tr>
@@ -62,6 +63,10 @@ $this->url('audit_compare',
                         <span class="label label-info">
                             <?php echo  ($revision->getUser()->getEmail()) ?: 'Anonymous'; ?>
                         </span>
+                        </td>
+
+                        <td>
+                            <?php echo $revision->getNote() ?>
                         </td>
 
                         <td>

--- a/view/zf2-entity-audit/index/viewentity.phtml
+++ b/view/zf2-entity-audit/index/viewentity.phtml
@@ -1,4 +1,4 @@
-<h1>Audit log for <?php  echo $this->escapeHtml($className); ?> identifier <?php  echo $this->escapeHtml($id); ?></h1>
+<h1>Audit log for <?php  echo $this->escapeHtml(str_replace($prefixToIgnore, '', $className)); ?> identifier <?php  echo $this->escapeHtml($id); ?></h1>
 
 <form action="<?=
 $this->url('audit_compare',

--- a/view/zf2-entity-audit/index/viewentity.phtml
+++ b/view/zf2-entity-audit/index/viewentity.phtml
@@ -1,4 +1,4 @@
-<h1>Audit log for <?php  echo $this->escapeHtml(str_replace($prefixToIgnore, '', $className)); ?> identifier <?php  echo $this->escapeHtml($id); ?></h1>
+<h1>Audit log for <?php echo $this->escapeHtml($this->entityLabel($entity, $className, $id, $prefixToIgnore)) ?></h1>
 
 <form action="<?=
 $this->url('audit_compare',

--- a/view/zf2-entity-audit/index/viewrevision.phtml
+++ b/view/zf2-entity-audit/index/viewrevision.phtml
@@ -54,7 +54,8 @@
                                     echo 'info';
                             }
                             ?>">
-                                    <?php echo $this->escapeHtml($ce->getClassName()); ?>
+                                <?php $displayClassName = str_replace($prefixToIgnore, '', $ce->getClassName()) ?>
+                                    <?php echo $this->escapeHtml($displayClassName); ?>
                             </span>
                     </td>
                     <td>


### PR DESCRIPTION
Pulled out some of the placeholder UI.
Added a config option for noteFormField. You can now add a form field with this name to whatever form is editing the audited entity. If the field has a value and the entity changes, the note will be saved with the revision. I also added the revision note to the UI.
Another new config option under the ui config: 'ignore.prefix'. Now, instead of the UI displaying Application\Entity\Post, it just displays Post.
If the audited entity has the method __toString, the result is now shown on the main audit log index view.